### PR TITLE
feat: Adds script for publishing only the dist.

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "ht2-release-private-circleci": "./scripts/private-circleci.js",
     "ht2-release-private-travisci": "./scripts/private-travisci.js",
     "ht2-release-public-circleci-app": "./scripts/public-circleci-app.js",
+    "ht2-release-public-circleci-lib-dist": "./scripts/public-circleci-lib-dist.js",
     "ht2-release-public-circleci-lib": "./scripts/public-circleci-lib.js",
     "ht2-release-public-travisci-app": "./scripts/public-travisci-app.js",
     "ht2-release-public-travisci-lib": "./scripts/public-travisci-lib.js"

--- a/readme.md
+++ b/readme.md
@@ -27,6 +27,7 @@ Project | Script
 --- | ---
 Public CircleCI App | `ht2-release-public-circleci-app`
 Public CircleCI Lib | `ht2-release-public-circleci-lib`
+Public CircleCI Lib (/dist only) | `ht2-release-public-circleci-lib-dist`
 Public TravisCI App | `ht2-release-public-travisci-app`
 Public TravisCI Lib | `ht2-release-public-travisci-lib`
 Private CircleCI | `ht2-release-private-circleci`

--- a/scripts/public-circleci-lib-dist.js
+++ b/scripts/public-circleci-lib-dist.js
@@ -1,0 +1,19 @@
+#!/usr/bin/env node
+const release = require('../utils/release');
+
+release({
+  "verifyConditions": [
+    "condition-circle",
+    "@semantic-release/github",
+    "@semantic-release/npm"
+  ],
+  "prepare": [
+    "@semantic-release/npm"
+  ],
+  "publish": [
+    "@semantic-release/github",
+    "@semantic-release/npm"
+  ],
+  "pkgRoot": "dist",
+  "assets": ["package.json", "license", "readme.md"],
+});


### PR DESCRIPTION
Uses the `pkgRoot` and `assets` options. Not sure if the `assets` option is going to work, may need to copy the "readme.md", "package.json", and "license" files into the dist before running semantic release.