### PR TITLE
fix(deps): Revert dependency semantic-release to v17.4.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -181,15 +181,15 @@
       }
     },
     "@semantic-release/commit-analyzer": {
-      "version": "9.0.2",
-      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-9.0.2.tgz",
-      "integrity": "sha512-E+dr6L+xIHZkX4zNMe6Rnwg4YQrWNXK+rNsvwOPpdFppvZO1olE2fIgWhv89TkQErygevbjsZFSIxp+u6w2e5g==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/@semantic-release/commit-analyzer/-/commit-analyzer-8.0.1.tgz",
+      "integrity": "sha512-5bJma/oB7B4MtwUkZC2Bf7O1MHfi4gWe4mA+MIQ3lsEV0b422Bvl1z5HRpplDnMLHH3EXMoRdEng6Ds5wUqA3A==",
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
+        "conventional-commits-parser": "^3.0.7",
         "debug": "^4.0.0",
-        "import-from": "^4.0.0",
+        "import-from": "^3.0.0",
         "lodash": "^4.17.4",
         "micromatch": "^4.0.2"
       }
@@ -267,17 +267,17 @@
       }
     },
     "@semantic-release/release-notes-generator": {
-      "version": "10.0.3",
-      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-10.0.3.tgz",
-      "integrity": "sha512-k4x4VhIKneOWoBGHkx0qZogNjCldLPRiAjnIpMnlUh6PtaWXp/T+C9U7/TaNDDtgDa5HMbHl4WlREdxHio6/3w==",
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/@semantic-release/release-notes-generator/-/release-notes-generator-9.0.3.tgz",
+      "integrity": "sha512-hMZyddr0u99OvM2SxVOIelHzly+PP3sYtJ8XOLHdMp8mrluN5/lpeTnIO27oeCYdupY/ndoGfvrqDjHqkSyhVg==",
       "requires": {
         "conventional-changelog-angular": "^5.0.0",
-        "conventional-changelog-writer": "^5.0.0",
+        "conventional-changelog-writer": "^4.0.0",
         "conventional-commits-filter": "^2.0.0",
-        "conventional-commits-parser": "^3.2.3",
+        "conventional-commits-parser": "^3.0.0",
         "debug": "^4.0.0",
         "get-stream": "^6.0.0",
-        "import-from": "^4.0.0",
+        "import-from": "^3.0.0",
         "into-stream": "^6.0.0",
         "lodash": "^4.17.4",
         "read-pkg-up": "^7.0.0"
@@ -335,17 +335,17 @@
       }
     },
     "ansi-escapes": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-5.0.0.tgz",
-      "integrity": "sha512-5GFMVX8HqE/TB+FuBJGuO5XG0WrsA6ptUqoODaT/n9mmUaZFkqnBueB4leqGBCmrUHnCnC4PCZTCd0E7QQ83bA==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-4.3.2.tgz",
+      "integrity": "sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==",
       "requires": {
-        "type-fest": "^1.0.2"
+        "type-fest": "^0.21.3"
       },
       "dependencies": {
         "type-fest": {
-          "version": "1.4.0",
-          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-          "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA=="
+          "version": "0.21.3",
+          "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
+          "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
         }
       }
     },
@@ -524,13 +524,14 @@
       }
     },
     "conventional-changelog-writer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-5.0.1.tgz",
-      "integrity": "sha512-5WsuKUfxW7suLblAbFnxAcrvf6r+0b7GvNaWUwUIk0bXMnENP/PEieGKVUQrjPqwPT4o3EPAASBXiY6iHooLOQ==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-writer/-/conventional-changelog-writer-4.1.0.tgz",
+      "integrity": "sha512-WwKcUp7WyXYGQmkLsX4QmU42AZ1lqlvRW9mqoyiQzdD+rJWbTepdWoKJuwXTS+yq79XKnQNa93/roViPQrAQgw==",
       "requires": {
+        "compare-func": "^2.0.0",
         "conventional-commits-filter": "^2.0.7",
         "dateformat": "^3.0.0",
-        "handlebars": "^4.7.7",
+        "handlebars": "^4.7.6",
         "json-stringify-safe": "^5.0.1",
         "lodash": "^4.17.15",
         "meow": "^8.0.0",
@@ -1087,9 +1088,12 @@
       }
     },
     "import-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/import-from/-/import-from-4.0.0.tgz",
-      "integrity": "sha512-P9J71vT5nLlDeV8FHs5nNxaLbrpfAV5cF5srvbZfpwpcJoM/xZR3hiv+q+SAnuSmuGbXMWud063iIMx/V/EWZQ=="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-from/-/import-from-3.0.0.tgz",
+      "integrity": "sha512-CiuXOFFSzkU5x/CR0+z7T91Iht4CXgfCxVOFRhh2Zyhg5wOpWvvDLQUsWl+gcN+QscYBjez8hDCt85O7RLDttQ==",
+      "requires": {
+        "resolve-from": "^5.0.0"
+      }
     },
     "indent-string": {
       "version": "4.0.0",
@@ -1348,27 +1352,65 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ=="
     },
     "marked": {
-      "version": "4.0.14",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-4.0.14.tgz",
-      "integrity": "sha512-HL5sSPE/LP6U9qKgngIIPTthuxC0jrfxpYMZ3LdGDD3vTnLs59m2Z7r6+LNDR3ToqEQdkKd6YaaEfJhodJmijQ=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-2.1.3.tgz",
+      "integrity": "sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA=="
     },
     "marked-terminal": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-5.1.1.tgz",
-      "integrity": "sha512-+cKTOx9P4l7HwINYhzbrBSyzgxO2HaHKGZGuB1orZsMIgXYaJyfidT81VXRdpelW/PcHEWxywscePVgI/oUF6g==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/marked-terminal/-/marked-terminal-4.2.0.tgz",
+      "integrity": "sha512-DQfNRV9svZf0Dm9Cf5x5xaVJ1+XjxQW6XjFJ5HFkVyK52SDpj5PCBzS5X5r2w9nHr3mlB0T5201UMLue9fmhUw==",
       "requires": {
-        "ansi-escapes": "^5.0.0",
+        "ansi-escapes": "^4.3.1",
         "cardinal": "^2.1.1",
-        "chalk": "^5.0.0",
-        "cli-table3": "^0.6.1",
-        "node-emoji": "^1.11.0",
-        "supports-hyperlinks": "^2.2.0"
+        "chalk": "^4.1.0",
+        "cli-table3": "^0.6.0",
+        "node-emoji": "^1.10.0",
+        "supports-hyperlinks": "^2.1.0"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+          "requires": {
+            "color-convert": "^2.0.1"
+          }
+        },
         "chalk": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.0.1.tgz",
-          "integrity": "sha512-Fo07WOYGqMfCWHOzSXOt2CxDbC6skS/jO9ynEcmpANMoPrD+W1r1K6Vx7iNm+AQmETU1Xr2t+n8nzkV9t6xh3w=="
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "requires": {
+            "has-flag": "^4.0.0"
+          }
         }
       }
     },
@@ -3708,15 +3750,15 @@
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
     },
     "semantic-release": {
-      "version": "19.0.2",
-      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-19.0.2.tgz",
-      "integrity": "sha512-7tPonjZxukKECmClhsfyMKDt0GR38feIC2HxgyYaBi+9tDySBLjK/zYDLhh+m6yjnHIJa9eBTKYE7k63ZQcYbw==",
+      "version": "17.4.7",
+      "resolved": "https://registry.npmjs.org/semantic-release/-/semantic-release-17.4.7.tgz",
+      "integrity": "sha512-3Ghu8mKCJgCG3QzE5xphkYWM19lGE3XjFdOXQIKBM2PBpBvgFQ/lXv31oX0+fuN/UjNFO/dqhNs8ATLBhg6zBg==",
       "requires": {
-        "@semantic-release/commit-analyzer": "^9.0.2",
-        "@semantic-release/error": "^3.0.0",
-        "@semantic-release/github": "^8.0.0",
-        "@semantic-release/npm": "^9.0.0",
-        "@semantic-release/release-notes-generator": "^10.0.0",
+        "@semantic-release/commit-analyzer": "^8.0.0",
+        "@semantic-release/error": "^2.2.0",
+        "@semantic-release/github": "^7.0.0",
+        "@semantic-release/npm": "^7.0.0",
+        "@semantic-release/release-notes-generator": "^9.0.0",
         "aggregate-error": "^3.0.0",
         "cosmiconfig": "^7.0.0",
         "debug": "^4.0.0",
@@ -3729,8 +3771,8 @@
         "hook-std": "^2.0.0",
         "hosted-git-info": "^4.0.0",
         "lodash": "^4.17.21",
-        "marked": "^4.0.10",
-        "marked-terminal": "^5.0.0",
+        "marked": "^2.0.0",
+        "marked-terminal": "^4.1.1",
         "micromatch": "^4.0.2",
         "p-each-series": "^2.1.0",
         "p-reduce": "^2.0.0",
@@ -3742,1549 +3784,12 @@
         "yargs": "^16.2.0"
       },
       "dependencies": {
-        "@semantic-release/error": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-3.0.0.tgz",
-          "integrity": "sha512-5hiM4Un+tpl4cKw3lV4UgzJj+SmfNIDCLLw0TepzQxz9ZGV5ixnqkzIVF+3tp0ZHgcMKE+VNGHJjEeyFG2dcSw=="
-        },
-        "@semantic-release/github": {
-          "version": "8.0.4",
-          "resolved": "https://registry.npmjs.org/@semantic-release/github/-/github-8.0.4.tgz",
-          "integrity": "sha512-But4e8oqqP3anZI5tjzZssZc2J6eoUdeeE0s7LVKKwyiAXJiQDWNNvtPOpgG2DsIz4+Exuse7cEQgjGMxwtLmg==",
-          "requires": {
-            "@octokit/rest": "^18.0.0",
-            "@semantic-release/error": "^2.2.0",
-            "aggregate-error": "^3.0.0",
-            "bottleneck": "^2.18.1",
-            "debug": "^4.0.0",
-            "dir-glob": "^3.0.0",
-            "fs-extra": "^10.0.0",
-            "globby": "^11.0.0",
-            "http-proxy-agent": "^5.0.0",
-            "https-proxy-agent": "^5.0.0",
-            "issue-parser": "^6.0.0",
-            "lodash": "^4.17.4",
-            "mime": "^3.0.0",
-            "p-filter": "^2.0.0",
-            "p-retry": "^4.0.0",
-            "url-join": "^4.0.0"
-          },
-          "dependencies": {
-            "@semantic-release/error": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/@semantic-release/error/-/error-2.2.0.tgz",
-              "integrity": "sha512-9Tj/qn+y2j+sjCI3Jd+qseGtHjOAeg7dU2/lVcqIQ9TV3QDaDXDYXcoOHU+7o2Hwh8L8ymL4gfuO7KxDs3q2zg=="
-            }
-          }
-        },
-        "@semantic-release/npm": {
-          "version": "9.0.1",
-          "resolved": "https://registry.npmjs.org/@semantic-release/npm/-/npm-9.0.1.tgz",
-          "integrity": "sha512-I5nVZklxBzfMFwemhRNbSrkiN/dsH3c7K9+KSk6jUnq0rdLFUuJt7EBsysq4Ir3moajQgFkfEryEHPqiKJj20g==",
-          "requires": {
-            "@semantic-release/error": "^3.0.0",
-            "aggregate-error": "^3.0.0",
-            "execa": "^5.0.0",
-            "fs-extra": "^10.0.0",
-            "lodash": "^4.17.15",
-            "nerf-dart": "^1.0.0",
-            "normalize-url": "^6.0.0",
-            "npm": "^8.3.0",
-            "rc": "^1.2.8",
-            "read-pkg": "^5.0.0",
-            "registry-auth-token": "^4.0.0",
-            "semver": "^7.1.2",
-            "tempy": "^1.0.0"
-          }
-        },
-        "@tootallnate/once": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-          "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A=="
-        },
-        "fs-extra": {
-          "version": "10.1.0",
-          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-10.1.0.tgz",
-          "integrity": "sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==",
-          "requires": {
-            "graceful-fs": "^4.2.0",
-            "jsonfile": "^6.0.1",
-            "universalify": "^2.0.0"
-          }
-        },
         "hosted-git-info": {
           "version": "4.1.0",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-4.1.0.tgz",
           "integrity": "sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==",
           "requires": {
             "lru-cache": "^6.0.0"
-          }
-        },
-        "http-proxy-agent": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
-          "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
-          "requires": {
-            "@tootallnate/once": "2",
-            "agent-base": "6",
-            "debug": "4"
-          }
-        },
-        "mime": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-          "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="
-        },
-        "npm": {
-          "version": "8.7.0",
-          "resolved": "https://registry.npmjs.org/npm/-/npm-8.7.0.tgz",
-          "integrity": "sha512-fOSunmSa1K3dBv4YFoX54wew3PC6aYYDMGWBAonWRO4Yc7smYtk3nLrCda6+dtkTJwA8D4Tv/0wmnpYNgf5VFw==",
-          "requires": {
-            "@isaacs/string-locale-compare": "^1.1.0",
-            "@npmcli/arborist": "^5.0.4",
-            "@npmcli/ci-detect": "^2.0.0",
-            "@npmcli/config": "^4.1.0",
-            "@npmcli/fs": "^2.1.0",
-            "@npmcli/map-workspaces": "^2.0.2",
-            "@npmcli/package-json": "^2.0.0",
-            "@npmcli/run-script": "^3.0.1",
-            "abbrev": "~1.1.1",
-            "archy": "~1.0.0",
-            "cacache": "^16.0.4",
-            "chalk": "^4.1.2",
-            "chownr": "^2.0.0",
-            "cli-columns": "^4.0.0",
-            "cli-table3": "^0.6.1",
-            "columnify": "^1.6.0",
-            "fastest-levenshtein": "^1.0.12",
-            "glob": "^7.2.0",
-            "graceful-fs": "^4.2.10",
-            "hosted-git-info": "^5.0.0",
-            "ini": "^3.0.0",
-            "init-package-json": "^3.0.2",
-            "is-cidr": "^4.0.2",
-            "json-parse-even-better-errors": "^2.3.1",
-            "libnpmaccess": "^6.0.2",
-            "libnpmdiff": "^4.0.2",
-            "libnpmexec": "^4.0.2",
-            "libnpmfund": "^3.0.1",
-            "libnpmhook": "^8.0.2",
-            "libnpmorg": "^4.0.2",
-            "libnpmpack": "^4.0.2",
-            "libnpmpublish": "^6.0.2",
-            "libnpmsearch": "^5.0.2",
-            "libnpmteam": "^4.0.2",
-            "libnpmversion": "^3.0.1",
-            "make-fetch-happen": "^10.1.2",
-            "minipass": "^3.1.6",
-            "minipass-pipeline": "^1.2.4",
-            "mkdirp": "^1.0.4",
-            "mkdirp-infer-owner": "^2.0.0",
-            "ms": "^2.1.2",
-            "node-gyp": "^9.0.0",
-            "nopt": "^5.0.0",
-            "npm-audit-report": "^3.0.0",
-            "npm-install-checks": "^5.0.0",
-            "npm-package-arg": "^9.0.2",
-            "npm-pick-manifest": "^7.0.1",
-            "npm-profile": "^6.0.2",
-            "npm-registry-fetch": "^13.1.0",
-            "npm-user-validate": "^1.0.1",
-            "npmlog": "^6.0.1",
-            "opener": "^1.5.2",
-            "pacote": "^13.1.1",
-            "parse-conflict-json": "^2.0.2",
-            "proc-log": "^2.0.1",
-            "qrcode-terminal": "^0.12.0",
-            "read": "~1.0.7",
-            "read-package-json": "^5.0.0",
-            "read-package-json-fast": "^2.0.3",
-            "readdir-scoped-modules": "^1.1.0",
-            "rimraf": "^3.0.2",
-            "semver": "^7.3.6",
-            "ssri": "^9.0.0",
-            "tar": "^6.1.11",
-            "text-table": "~0.2.0",
-            "tiny-relative-date": "^1.3.0",
-            "treeverse": "^2.0.0",
-            "validate-npm-package-name": "^4.0.0",
-            "which": "^2.0.2",
-            "write-file-atomic": "^4.0.1"
-          },
-          "dependencies": {
-            "@gar/promisify": {
-              "version": "1.1.3",
-              "bundled": true
-            },
-            "@isaacs/string-locale-compare": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "@npmcli/arborist": {
-              "version": "5.0.6",
-              "bundled": true,
-              "requires": {
-                "@isaacs/string-locale-compare": "^1.1.0",
-                "@npmcli/installed-package-contents": "^1.0.7",
-                "@npmcli/map-workspaces": "^2.0.0",
-                "@npmcli/metavuln-calculator": "^3.0.1",
-                "@npmcli/move-file": "^2.0.0",
-                "@npmcli/name-from-folder": "^1.0.1",
-                "@npmcli/node-gyp": "^2.0.0",
-                "@npmcli/package-json": "^2.0.0",
-                "@npmcli/run-script": "^3.0.0",
-                "bin-links": "^3.0.0",
-                "cacache": "^16.0.0",
-                "common-ancestor-path": "^1.0.1",
-                "json-parse-even-better-errors": "^2.3.1",
-                "json-stringify-nice": "^1.1.4",
-                "mkdirp": "^1.0.4",
-                "mkdirp-infer-owner": "^2.0.0",
-                "nopt": "^5.0.0",
-                "npm-install-checks": "^5.0.0",
-                "npm-package-arg": "^9.0.0",
-                "npm-pick-manifest": "^7.0.0",
-                "npm-registry-fetch": "^13.0.0",
-                "npmlog": "^6.0.1",
-                "pacote": "^13.0.5",
-                "parse-conflict-json": "^2.0.1",
-                "proc-log": "^2.0.0",
-                "promise-all-reject-late": "^1.0.0",
-                "promise-call-limit": "^1.0.1",
-                "read-package-json-fast": "^2.0.2",
-                "readdir-scoped-modules": "^1.1.0",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "ssri": "^9.0.0",
-                "treeverse": "^2.0.0",
-                "walk-up-path": "^1.0.0"
-              }
-            },
-            "@npmcli/ci-detect": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "@npmcli/config": {
-              "version": "4.1.0",
-              "bundled": true,
-              "requires": {
-                "@npmcli/map-workspaces": "^2.0.2",
-                "ini": "^3.0.0",
-                "mkdirp-infer-owner": "^2.0.0",
-                "nopt": "^5.0.0",
-                "proc-log": "^2.0.0",
-                "read-package-json-fast": "^2.0.3",
-                "semver": "^7.3.5",
-                "walk-up-path": "^1.0.0"
-              }
-            },
-            "@npmcli/disparity-colors": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^4.3.0"
-              }
-            },
-            "@npmcli/fs": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "@gar/promisify": "^1.1.3",
-                "semver": "^7.3.5"
-              }
-            },
-            "@npmcli/git": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "@npmcli/promise-spawn": "^3.0.0",
-                "lru-cache": "^7.4.4",
-                "mkdirp": "^1.0.4",
-                "npm-pick-manifest": "^7.0.0",
-                "proc-log": "^2.0.0",
-                "promise-inflight": "^1.0.1",
-                "promise-retry": "^2.0.1",
-                "semver": "^7.3.5",
-                "which": "^2.0.2"
-              }
-            },
-            "@npmcli/installed-package-contents": {
-              "version": "1.0.7",
-              "bundled": true,
-              "requires": {
-                "npm-bundled": "^1.1.1",
-                "npm-normalize-package-bin": "^1.0.1"
-              }
-            },
-            "@npmcli/map-workspaces": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "@npmcli/name-from-folder": "^1.0.1",
-                "glob": "^7.2.0",
-                "minimatch": "^5.0.1",
-                "read-package-json-fast": "^2.0.3"
-              }
-            },
-            "@npmcli/metavuln-calculator": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "cacache": "^16.0.0",
-                "json-parse-even-better-errors": "^2.3.1",
-                "pacote": "^13.0.3",
-                "semver": "^7.3.5"
-              }
-            },
-            "@npmcli/move-file": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "mkdirp": "^1.0.4",
-                "rimraf": "^3.0.2"
-              }
-            },
-            "@npmcli/name-from-folder": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "@npmcli/node-gyp": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "@npmcli/package-json": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "json-parse-even-better-errors": "^2.3.1"
-              }
-            },
-            "@npmcli/promise-spawn": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "infer-owner": "^1.0.4"
-              }
-            },
-            "@npmcli/run-script": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "@npmcli/node-gyp": "^2.0.0",
-                "@npmcli/promise-spawn": "^3.0.0",
-                "node-gyp": "^9.0.0",
-                "read-package-json-fast": "^2.0.3"
-              }
-            },
-            "@tootallnate/once": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "abbrev": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "agent-base": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "debug": "4"
-              }
-            },
-            "agentkeepalive": {
-              "version": "4.2.1",
-              "bundled": true,
-              "requires": {
-                "debug": "^4.1.0",
-                "depd": "^1.1.2",
-                "humanize-ms": "^1.2.1"
-              }
-            },
-            "aggregate-error": {
-              "version": "3.1.0",
-              "bundled": true,
-              "requires": {
-                "clean-stack": "^2.0.0",
-                "indent-string": "^4.0.0"
-              }
-            },
-            "ansi-regex": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "ansi-styles": {
-              "version": "4.3.0",
-              "bundled": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            },
-            "aproba": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "archy": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "are-we-there-yet": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "delegates": "^1.0.0",
-                "readable-stream": "^3.6.0"
-              }
-            },
-            "asap": {
-              "version": "2.0.6",
-              "bundled": true
-            },
-            "balanced-match": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "bin-links": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "cmd-shim": "^5.0.0",
-                "mkdirp-infer-owner": "^2.0.0",
-                "npm-normalize-package-bin": "^1.0.0",
-                "read-cmd-shim": "^3.0.0",
-                "rimraf": "^3.0.0",
-                "write-file-atomic": "^4.0.0"
-              }
-            },
-            "binary-extensions": {
-              "version": "2.2.0",
-              "bundled": true
-            },
-            "brace-expansion": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "balanced-match": "^1.0.0"
-              }
-            },
-            "builtins": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "semver": "^7.0.0"
-              }
-            },
-            "cacache": {
-              "version": "16.0.4",
-              "bundled": true,
-              "requires": {
-                "@npmcli/fs": "^2.1.0",
-                "@npmcli/move-file": "^2.0.0",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.1.0",
-                "glob": "^7.2.0",
-                "infer-owner": "^1.0.4",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "mkdirp": "^1.0.4",
-                "p-map": "^4.0.0",
-                "promise-inflight": "^1.0.1",
-                "rimraf": "^3.0.2",
-                "ssri": "^9.0.0",
-                "tar": "^6.1.11",
-                "unique-filename": "^1.1.1"
-              }
-            },
-            "chalk": {
-              "version": "4.1.2",
-              "bundled": true,
-              "requires": {
-                "ansi-styles": "^4.1.0",
-                "supports-color": "^7.1.0"
-              }
-            },
-            "chownr": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "cidr-regex": {
-              "version": "3.1.1",
-              "bundled": true,
-              "requires": {
-                "ip-regex": "^4.1.0"
-              }
-            },
-            "clean-stack": {
-              "version": "2.2.0",
-              "bundled": true
-            },
-            "cli-columns": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1"
-              }
-            },
-            "cli-table3": {
-              "version": "0.6.1",
-              "bundled": true,
-              "requires": {
-                "colors": "1.4.0",
-                "string-width": "^4.2.0"
-              }
-            },
-            "clone": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "cmd-shim": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "mkdirp-infer-owner": "^2.0.0"
-              }
-            },
-            "color-convert": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "color-name": "~1.1.4"
-              }
-            },
-            "color-name": {
-              "version": "1.1.4",
-              "bundled": true
-            },
-            "color-support": {
-              "version": "1.1.3",
-              "bundled": true
-            },
-            "colors": {
-              "version": "1.4.0",
-              "bundled": true,
-              "optional": true
-            },
-            "columnify": {
-              "version": "1.6.0",
-              "bundled": true,
-              "requires": {
-                "strip-ansi": "^6.0.1",
-                "wcwidth": "^1.0.0"
-              }
-            },
-            "common-ancestor-path": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "concat-map": {
-              "version": "0.0.1",
-              "bundled": true
-            },
-            "console-control-strings": {
-              "version": "1.1.0",
-              "bundled": true
-            },
-            "debug": {
-              "version": "4.3.4",
-              "bundled": true,
-              "requires": {
-                "ms": "2.1.2"
-              },
-              "dependencies": {
-                "ms": {
-                  "version": "2.1.2",
-                  "bundled": true
-                }
-              }
-            },
-            "debuglog": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "defaults": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "clone": "^1.0.2"
-              }
-            },
-            "delegates": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "depd": {
-              "version": "1.1.2",
-              "bundled": true
-            },
-            "dezalgo": {
-              "version": "1.0.4",
-              "bundled": true,
-              "requires": {
-                "asap": "^2.0.0",
-                "wrappy": "1"
-              }
-            },
-            "diff": {
-              "version": "5.0.0",
-              "bundled": true
-            },
-            "emoji-regex": {
-              "version": "8.0.0",
-              "bundled": true
-            },
-            "encoding": {
-              "version": "0.1.13",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "iconv-lite": "^0.6.2"
-              }
-            },
-            "env-paths": {
-              "version": "2.2.1",
-              "bundled": true
-            },
-            "err-code": {
-              "version": "2.0.3",
-              "bundled": true
-            },
-            "fastest-levenshtein": {
-              "version": "1.0.12",
-              "bundled": true
-            },
-            "fs-minipass": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "minipass": "^3.0.0"
-              }
-            },
-            "fs.realpath": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "function-bind": {
-              "version": "1.1.1",
-              "bundled": true
-            },
-            "gauge": {
-              "version": "4.0.4",
-              "bundled": true,
-              "requires": {
-                "aproba": "^1.0.3 || ^2.0.0",
-                "color-support": "^1.1.3",
-                "console-control-strings": "^1.1.0",
-                "has-unicode": "^2.0.1",
-                "signal-exit": "^3.0.7",
-                "string-width": "^4.2.3",
-                "strip-ansi": "^6.0.1",
-                "wide-align": "^1.1.5"
-              }
-            },
-            "glob": {
-              "version": "7.2.0",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              },
-              "dependencies": {
-                "brace-expansion": {
-                  "version": "1.1.11",
-                  "bundled": true,
-                  "requires": {
-                    "balanced-match": "^1.0.0",
-                    "concat-map": "0.0.1"
-                  }
-                },
-                "minimatch": {
-                  "version": "3.1.2",
-                  "bundled": true,
-                  "requires": {
-                    "brace-expansion": "^1.1.7"
-                  }
-                }
-              }
-            },
-            "graceful-fs": {
-              "version": "4.2.10",
-              "bundled": true
-            },
-            "has": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "function-bind": "^1.1.1"
-              }
-            },
-            "has-flag": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "has-unicode": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "hosted-git-info": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "^7.5.1"
-              }
-            },
-            "http-cache-semantics": {
-              "version": "4.1.0",
-              "bundled": true
-            },
-            "http-proxy-agent": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "@tootallnate/once": "2",
-                "agent-base": "6",
-                "debug": "4"
-              }
-            },
-            "https-proxy-agent": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "agent-base": "6",
-                "debug": "4"
-              }
-            },
-            "humanize-ms": {
-              "version": "1.2.1",
-              "bundled": true,
-              "requires": {
-                "ms": "^2.0.0"
-              }
-            },
-            "iconv-lite": {
-              "version": "0.6.3",
-              "bundled": true,
-              "optional": true,
-              "requires": {
-                "safer-buffer": ">= 2.1.2 < 3.0.0"
-              }
-            },
-            "ignore-walk": {
-              "version": "5.0.1",
-              "bundled": true,
-              "requires": {
-                "minimatch": "^5.0.1"
-              }
-            },
-            "imurmurhash": {
-              "version": "0.1.4",
-              "bundled": true
-            },
-            "indent-string": {
-              "version": "4.0.0",
-              "bundled": true
-            },
-            "infer-owner": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "inflight": {
-              "version": "1.0.6",
-              "bundled": true,
-              "requires": {
-                "once": "^1.3.0",
-                "wrappy": "1"
-              }
-            },
-            "inherits": {
-              "version": "2.0.4",
-              "bundled": true
-            },
-            "ini": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "init-package-json": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "npm-package-arg": "^9.0.1",
-                "promzard": "^0.3.0",
-                "read": "^1.0.7",
-                "read-package-json": "^5.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-license": "^3.0.4",
-                "validate-npm-package-name": "^4.0.0"
-              }
-            },
-            "ip": {
-              "version": "1.1.5",
-              "bundled": true
-            },
-            "ip-regex": {
-              "version": "4.3.0",
-              "bundled": true
-            },
-            "is-cidr": {
-              "version": "4.0.2",
-              "bundled": true,
-              "requires": {
-                "cidr-regex": "^3.1.1"
-              }
-            },
-            "is-core-module": {
-              "version": "2.8.1",
-              "bundled": true,
-              "requires": {
-                "has": "^1.0.3"
-              }
-            },
-            "is-fullwidth-code-point": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "is-lambda": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "isexe": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "json-parse-even-better-errors": {
-              "version": "2.3.1",
-              "bundled": true
-            },
-            "json-stringify-nice": {
-              "version": "1.1.4",
-              "bundled": true
-            },
-            "jsonparse": {
-              "version": "1.3.1",
-              "bundled": true
-            },
-            "just-diff": {
-              "version": "5.0.1",
-              "bundled": true
-            },
-            "just-diff-apply": {
-              "version": "5.2.0",
-              "bundled": true
-            },
-            "libnpmaccess": {
-              "version": "6.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "minipass": "^3.1.1",
-                "npm-package-arg": "^9.0.1",
-                "npm-registry-fetch": "^13.0.0"
-              }
-            },
-            "libnpmdiff": {
-              "version": "4.0.3",
-              "bundled": true,
-              "requires": {
-                "@npmcli/disparity-colors": "^2.0.0",
-                "@npmcli/installed-package-contents": "^1.0.7",
-                "binary-extensions": "^2.2.0",
-                "diff": "^5.0.0",
-                "minimatch": "^5.0.1",
-                "npm-package-arg": "^9.0.1",
-                "pacote": "^13.0.5",
-                "tar": "^6.1.0"
-              }
-            },
-            "libnpmexec": {
-              "version": "4.0.3",
-              "bundled": true,
-              "requires": {
-                "@npmcli/arborist": "^5.0.0",
-                "@npmcli/ci-detect": "^2.0.0",
-                "@npmcli/run-script": "^3.0.0",
-                "chalk": "^4.1.0",
-                "mkdirp-infer-owner": "^2.0.0",
-                "npm-package-arg": "^9.0.1",
-                "npmlog": "^6.0.1",
-                "pacote": "^13.0.5",
-                "proc-log": "^2.0.0",
-                "read": "^1.0.7",
-                "read-package-json-fast": "^2.0.2",
-                "walk-up-path": "^1.0.0"
-              }
-            },
-            "libnpmfund": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "@npmcli/arborist": "^5.0.0"
-              }
-            },
-            "libnpmhook": {
-              "version": "8.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "npm-registry-fetch": "^13.0.0"
-              }
-            },
-            "libnpmorg": {
-              "version": "4.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "npm-registry-fetch": "^13.0.0"
-              }
-            },
-            "libnpmpack": {
-              "version": "4.0.3",
-              "bundled": true,
-              "requires": {
-                "@npmcli/run-script": "^3.0.0",
-                "npm-package-arg": "^9.0.1",
-                "pacote": "^13.0.5"
-              }
-            },
-            "libnpmpublish": {
-              "version": "6.0.3",
-              "bundled": true,
-              "requires": {
-                "normalize-package-data": "^4.0.0",
-                "npm-package-arg": "^9.0.1",
-                "npm-registry-fetch": "^13.0.0",
-                "semver": "^7.1.3",
-                "ssri": "^9.0.0"
-              }
-            },
-            "libnpmsearch": {
-              "version": "5.0.3",
-              "bundled": true,
-              "requires": {
-                "npm-registry-fetch": "^13.0.0"
-              }
-            },
-            "libnpmteam": {
-              "version": "4.0.3",
-              "bundled": true,
-              "requires": {
-                "aproba": "^2.0.0",
-                "npm-registry-fetch": "^13.0.0"
-              }
-            },
-            "libnpmversion": {
-              "version": "3.0.3",
-              "bundled": true,
-              "requires": {
-                "@npmcli/git": "^3.0.0",
-                "@npmcli/run-script": "^3.0.0",
-                "json-parse-even-better-errors": "^2.3.1",
-                "proc-log": "^2.0.0",
-                "semver": "^7.3.5"
-              }
-            },
-            "lru-cache": {
-              "version": "7.7.3",
-              "bundled": true
-            },
-            "make-fetch-happen": {
-              "version": "10.1.2",
-              "bundled": true,
-              "requires": {
-                "agentkeepalive": "^4.2.1",
-                "cacache": "^16.0.2",
-                "http-cache-semantics": "^4.1.0",
-                "http-proxy-agent": "^5.0.0",
-                "https-proxy-agent": "^5.0.0",
-                "is-lambda": "^1.0.1",
-                "lru-cache": "^7.7.1",
-                "minipass": "^3.1.6",
-                "minipass-collect": "^1.0.2",
-                "minipass-fetch": "^2.0.3",
-                "minipass-flush": "^1.0.5",
-                "minipass-pipeline": "^1.2.4",
-                "negotiator": "^0.6.3",
-                "promise-retry": "^2.0.1",
-                "socks-proxy-agent": "^6.1.1",
-                "ssri": "^9.0.0"
-              }
-            },
-            "minimatch": {
-              "version": "5.0.1",
-              "bundled": true,
-              "requires": {
-                "brace-expansion": "^2.0.1"
-              }
-            },
-            "minipass": {
-              "version": "3.1.6",
-              "bundled": true,
-              "requires": {
-                "yallist": "^4.0.0"
-              }
-            },
-            "minipass-collect": {
-              "version": "1.0.2",
-              "bundled": true,
-              "requires": {
-                "minipass": "^3.0.0"
-              }
-            },
-            "minipass-fetch": {
-              "version": "2.1.0",
-              "bundled": true,
-              "requires": {
-                "encoding": "^0.1.13",
-                "minipass": "^3.1.6",
-                "minipass-sized": "^1.0.3",
-                "minizlib": "^2.1.2"
-              }
-            },
-            "minipass-flush": {
-              "version": "1.0.5",
-              "bundled": true,
-              "requires": {
-                "minipass": "^3.0.0"
-              }
-            },
-            "minipass-json-stream": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "jsonparse": "^1.3.1",
-                "minipass": "^3.0.0"
-              }
-            },
-            "minipass-pipeline": {
-              "version": "1.2.4",
-              "bundled": true,
-              "requires": {
-                "minipass": "^3.0.0"
-              }
-            },
-            "minipass-sized": {
-              "version": "1.0.3",
-              "bundled": true,
-              "requires": {
-                "minipass": "^3.0.0"
-              }
-            },
-            "minizlib": {
-              "version": "2.1.2",
-              "bundled": true,
-              "requires": {
-                "minipass": "^3.0.0",
-                "yallist": "^4.0.0"
-              }
-            },
-            "mkdirp": {
-              "version": "1.0.4",
-              "bundled": true
-            },
-            "mkdirp-infer-owner": {
-              "version": "2.0.0",
-              "bundled": true,
-              "requires": {
-                "chownr": "^2.0.0",
-                "infer-owner": "^1.0.4",
-                "mkdirp": "^1.0.3"
-              }
-            },
-            "ms": {
-              "version": "2.1.3",
-              "bundled": true
-            },
-            "mute-stream": {
-              "version": "0.0.8",
-              "bundled": true
-            },
-            "negotiator": {
-              "version": "0.6.3",
-              "bundled": true
-            },
-            "node-gyp": {
-              "version": "9.0.0",
-              "bundled": true,
-              "requires": {
-                "env-paths": "^2.2.0",
-                "glob": "^7.1.4",
-                "graceful-fs": "^4.2.6",
-                "make-fetch-happen": "^10.0.3",
-                "nopt": "^5.0.0",
-                "npmlog": "^6.0.0",
-                "rimraf": "^3.0.2",
-                "semver": "^7.3.5",
-                "tar": "^6.1.2",
-                "which": "^2.0.2"
-              }
-            },
-            "nopt": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "abbrev": "1"
-              }
-            },
-            "normalize-package-data": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "^5.0.0",
-                "is-core-module": "^2.8.1",
-                "semver": "^7.3.5",
-                "validate-npm-package-license": "^3.0.4"
-              }
-            },
-            "npm-audit-report": {
-              "version": "3.0.0",
-              "bundled": true,
-              "requires": {
-                "chalk": "^4.0.0"
-              }
-            },
-            "npm-bundled": {
-              "version": "1.1.2",
-              "bundled": true,
-              "requires": {
-                "npm-normalize-package-bin": "^1.0.1"
-              }
-            },
-            "npm-install-checks": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "semver": "^7.1.1"
-              }
-            },
-            "npm-normalize-package-bin": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "npm-package-arg": {
-              "version": "9.0.2",
-              "bundled": true,
-              "requires": {
-                "hosted-git-info": "^5.0.0",
-                "semver": "^7.3.5",
-                "validate-npm-package-name": "^4.0.0"
-              }
-            },
-            "npm-packlist": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.2.0",
-                "ignore-walk": "^5.0.1",
-                "npm-bundled": "^1.1.2",
-                "npm-normalize-package-bin": "^1.0.1"
-              }
-            },
-            "npm-pick-manifest": {
-              "version": "7.0.1",
-              "bundled": true,
-              "requires": {
-                "npm-install-checks": "^5.0.0",
-                "npm-normalize-package-bin": "^1.0.1",
-                "npm-package-arg": "^9.0.0",
-                "semver": "^7.3.5"
-              }
-            },
-            "npm-profile": {
-              "version": "6.0.2",
-              "bundled": true,
-              "requires": {
-                "npm-registry-fetch": "^13.0.0",
-                "proc-log": "^2.0.0"
-              }
-            },
-            "npm-registry-fetch": {
-              "version": "13.1.0",
-              "bundled": true,
-              "requires": {
-                "make-fetch-happen": "^10.0.6",
-                "minipass": "^3.1.6",
-                "minipass-fetch": "^2.0.3",
-                "minipass-json-stream": "^1.0.1",
-                "minizlib": "^2.1.2",
-                "npm-package-arg": "^9.0.1",
-                "proc-log": "^2.0.0"
-              }
-            },
-            "npm-user-validate": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "npmlog": {
-              "version": "6.0.1",
-              "bundled": true,
-              "requires": {
-                "are-we-there-yet": "^3.0.0",
-                "console-control-strings": "^1.1.0",
-                "gauge": "^4.0.0",
-                "set-blocking": "^2.0.0"
-              }
-            },
-            "once": {
-              "version": "1.4.0",
-              "bundled": true,
-              "requires": {
-                "wrappy": "1"
-              }
-            },
-            "opener": {
-              "version": "1.5.2",
-              "bundled": true
-            },
-            "p-map": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "aggregate-error": "^3.0.0"
-              }
-            },
-            "pacote": {
-              "version": "13.1.1",
-              "bundled": true,
-              "requires": {
-                "@npmcli/git": "^3.0.0",
-                "@npmcli/installed-package-contents": "^1.0.7",
-                "@npmcli/promise-spawn": "^3.0.0",
-                "@npmcli/run-script": "^3.0.1",
-                "cacache": "^16.0.0",
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.1.0",
-                "infer-owner": "^1.0.4",
-                "minipass": "^3.1.6",
-                "mkdirp": "^1.0.4",
-                "npm-package-arg": "^9.0.0",
-                "npm-packlist": "^5.0.0",
-                "npm-pick-manifest": "^7.0.0",
-                "npm-registry-fetch": "^13.0.1",
-                "proc-log": "^2.0.0",
-                "promise-retry": "^2.0.1",
-                "read-package-json": "^5.0.0",
-                "read-package-json-fast": "^2.0.3",
-                "rimraf": "^3.0.2",
-                "ssri": "^9.0.0",
-                "tar": "^6.1.11"
-              }
-            },
-            "parse-conflict-json": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "json-parse-even-better-errors": "^2.3.1",
-                "just-diff": "^5.0.1",
-                "just-diff-apply": "^5.2.0"
-              }
-            },
-            "path-is-absolute": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "proc-log": {
-              "version": "2.0.1",
-              "bundled": true
-            },
-            "promise-all-reject-late": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "promise-call-limit": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "promise-inflight": {
-              "version": "1.0.1",
-              "bundled": true
-            },
-            "promise-retry": {
-              "version": "2.0.1",
-              "bundled": true,
-              "requires": {
-                "err-code": "^2.0.2",
-                "retry": "^0.12.0"
-              }
-            },
-            "promzard": {
-              "version": "0.3.0",
-              "bundled": true,
-              "requires": {
-                "read": "1"
-              }
-            },
-            "qrcode-terminal": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "read": {
-              "version": "1.0.7",
-              "bundled": true,
-              "requires": {
-                "mute-stream": "~0.0.4"
-              }
-            },
-            "read-cmd-shim": {
-              "version": "3.0.0",
-              "bundled": true
-            },
-            "read-package-json": {
-              "version": "5.0.0",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.2.0",
-                "json-parse-even-better-errors": "^2.3.1",
-                "normalize-package-data": "^4.0.0",
-                "npm-normalize-package-bin": "^1.0.1"
-              }
-            },
-            "read-package-json-fast": {
-              "version": "2.0.3",
-              "bundled": true,
-              "requires": {
-                "json-parse-even-better-errors": "^2.3.0",
-                "npm-normalize-package-bin": "^1.0.1"
-              }
-            },
-            "readable-stream": {
-              "version": "3.6.0",
-              "bundled": true,
-              "requires": {
-                "inherits": "^2.0.3",
-                "string_decoder": "^1.1.1",
-                "util-deprecate": "^1.0.1"
-              }
-            },
-            "readdir-scoped-modules": {
-              "version": "1.1.0",
-              "bundled": true,
-              "requires": {
-                "debuglog": "^1.0.1",
-                "dezalgo": "^1.0.0",
-                "graceful-fs": "^4.1.2",
-                "once": "^1.3.0"
-              }
-            },
-            "retry": {
-              "version": "0.12.0",
-              "bundled": true
-            },
-            "rimraf": {
-              "version": "3.0.2",
-              "bundled": true,
-              "requires": {
-                "glob": "^7.1.3"
-              }
-            },
-            "safe-buffer": {
-              "version": "5.2.1",
-              "bundled": true
-            },
-            "safer-buffer": {
-              "version": "2.1.2",
-              "bundled": true,
-              "optional": true
-            },
-            "semver": {
-              "version": "7.3.6",
-              "bundled": true,
-              "requires": {
-                "lru-cache": "^7.4.0"
-              }
-            },
-            "set-blocking": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "signal-exit": {
-              "version": "3.0.7",
-              "bundled": true
-            },
-            "smart-buffer": {
-              "version": "4.2.0",
-              "bundled": true
-            },
-            "socks": {
-              "version": "2.6.2",
-              "bundled": true,
-              "requires": {
-                "ip": "^1.1.5",
-                "smart-buffer": "^4.2.0"
-              }
-            },
-            "socks-proxy-agent": {
-              "version": "6.1.1",
-              "bundled": true,
-              "requires": {
-                "agent-base": "^6.0.2",
-                "debug": "^4.3.1",
-                "socks": "^2.6.1"
-              }
-            },
-            "spdx-correct": {
-              "version": "3.1.1",
-              "bundled": true,
-              "requires": {
-                "spdx-expression-parse": "^3.0.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            },
-            "spdx-exceptions": {
-              "version": "2.3.0",
-              "bundled": true
-            },
-            "spdx-expression-parse": {
-              "version": "3.0.1",
-              "bundled": true,
-              "requires": {
-                "spdx-exceptions": "^2.1.0",
-                "spdx-license-ids": "^3.0.0"
-              }
-            },
-            "spdx-license-ids": {
-              "version": "3.0.11",
-              "bundled": true
-            },
-            "ssri": {
-              "version": "9.0.0",
-              "bundled": true,
-              "requires": {
-                "minipass": "^3.1.1"
-              }
-            },
-            "string-width": {
-              "version": "4.2.3",
-              "bundled": true,
-              "requires": {
-                "emoji-regex": "^8.0.0",
-                "is-fullwidth-code-point": "^3.0.0",
-                "strip-ansi": "^6.0.1"
-              }
-            },
-            "string_decoder": {
-              "version": "1.3.0",
-              "bundled": true,
-              "requires": {
-                "safe-buffer": "~5.2.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "6.0.1",
-              "bundled": true,
-              "requires": {
-                "ansi-regex": "^5.0.1"
-              }
-            },
-            "supports-color": {
-              "version": "7.2.0",
-              "bundled": true,
-              "requires": {
-                "has-flag": "^4.0.0"
-              }
-            },
-            "tar": {
-              "version": "6.1.11",
-              "bundled": true,
-              "requires": {
-                "chownr": "^2.0.0",
-                "fs-minipass": "^2.0.0",
-                "minipass": "^3.0.0",
-                "minizlib": "^2.1.1",
-                "mkdirp": "^1.0.3",
-                "yallist": "^4.0.0"
-              }
-            },
-            "text-table": {
-              "version": "0.2.0",
-              "bundled": true
-            },
-            "tiny-relative-date": {
-              "version": "1.3.0",
-              "bundled": true
-            },
-            "treeverse": {
-              "version": "2.0.0",
-              "bundled": true
-            },
-            "unique-filename": {
-              "version": "1.1.1",
-              "bundled": true,
-              "requires": {
-                "unique-slug": "^2.0.0"
-              }
-            },
-            "unique-slug": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "^0.1.4"
-              }
-            },
-            "util-deprecate": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "validate-npm-package-license": {
-              "version": "3.0.4",
-              "bundled": true,
-              "requires": {
-                "spdx-correct": "^3.0.0",
-                "spdx-expression-parse": "^3.0.0"
-              }
-            },
-            "validate-npm-package-name": {
-              "version": "4.0.0",
-              "bundled": true,
-              "requires": {
-                "builtins": "^5.0.0"
-              }
-            },
-            "walk-up-path": {
-              "version": "1.0.0",
-              "bundled": true
-            },
-            "wcwidth": {
-              "version": "1.0.1",
-              "bundled": true,
-              "requires": {
-                "defaults": "^1.0.3"
-              }
-            },
-            "which": {
-              "version": "2.0.2",
-              "bundled": true,
-              "requires": {
-                "isexe": "^2.0.0"
-              }
-            },
-            "wide-align": {
-              "version": "1.1.5",
-              "bundled": true,
-              "requires": {
-                "string-width": "^1.0.2 || 2 || 3 || 4"
-              }
-            },
-            "wrappy": {
-              "version": "1.0.2",
-              "bundled": true
-            },
-            "write-file-atomic": {
-              "version": "4.0.1",
-              "bundled": true,
-              "requires": {
-                "imurmurhash": "^0.1.4",
-                "signal-exit": "^3.0.7"
-              }
-            },
-            "yallist": {
-              "version": "4.0.0",
-              "bundled": true
-            }
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "@semantic-release/github": "7.2.3",
     "@semantic-release/npm": "7.1.3",
     "fs-extra": "^9.0.0",
-    "semantic-release": "19.0.2",
+    "semantic-release": "17.4.7",
     "semantic-release-docker": "2.2.0",
     "semver": "7.3.7",
     "simple-git": "3.7.1"


### PR DESCRIPTION
Release [v2.0.99](https://github.com/HT2-Labs/semantic-release/releases/tag/v2.0.99) removed support for node 12, which should have been a breaking change. This reverts the major version bump of the semantic-release dependency, moving from v19.0.2 back to v17.4.7